### PR TITLE
Use AMD module format as supported by almond

### DIFF
--- a/JSNLog.Tests/Scripts/libs/jsnlog.js
+++ b/JSNLog.Tests/Scripts/libs/jsnlog.js
@@ -709,7 +709,7 @@ if (typeof exports !== 'undefined') {
 // Support AMD module format
 var define;
 if (typeof define == 'function' && define.amd) {
-    define(function () {
+    define('jsnlog', [], function () {
         return JL;
     });
 }


### PR DESCRIPTION
It's common to use almond instead of RequireJS in production if you use the RequireJS optimizer. The benefit is a smaller download and fewer requests.

I updated the AMD definition to use the one that is supported by almond. It is also the same format that jQuery and Backbone use.

More info available here: https://github.com/jrburke/almond#common-errors

Without this change, the jsnlog AMD definition would throw an undefined method error here: https://github.com/jrburke/almond/blob/master/almond.js#L405
