### PR TITLE
Added safeguard for HTTP/1.0 requests

### DIFF
--- a/jsnlog/Infrastructure/AspNet5/HttpExtensions.cs
+++ b/jsnlog/Infrastructure/AspNet5/HttpExtensions.cs
@@ -25,7 +25,7 @@ namespace JSNLog.Infrastructure.AspNet5
             var queryString = request.QueryString.Value;
 
             // PERF: Calculate string length to allocate correct buffer size for StringBuilder.
-            var length = request.Scheme.Length + SchemeDelimiter.Length + host.Length
+            var length = request.Scheme.Length + SchemeDelimiter.Length + (host?.Length ?? 0)
                 + pathBase.Length + path.Length + queryString.Length;
 
             return new StringBuilder(length)


### PR DESCRIPTION
Added safeguard for HTTP/1.0 requests where Host.Value is null.

Example issue: using HAProxy with default configuration generates exceptions due to Host.Value being null