### PR TITLE
extend jsnlog to allow custom batch processing on the server side.

### DIFF
--- a/jsnlog/LogHandling/LoggerProcessor.cs
+++ b/jsnlog/LogHandling/LoggerProcessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using JSNLog.Infrastructure;
 using System.Net;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using JSNLog.Exceptions;
 
 namespace JSNLog.LogHandling
@@ -56,7 +57,7 @@ namespace JSNLog.LogHandling
         /// <param name="response">
         /// Empty response object. This method can add headers, etc.
         /// </param>
-        internal static void ProcessLogRequest(string json, LogRequestBase logRequestBase,
+        internal static async Task ProcessLogRequest(string json, LogRequestBase logRequestBase,
             DateTime serverSideTimeUtc,
             string httpMethod, string origin, LogResponse response)
         {
@@ -103,7 +104,7 @@ namespace JSNLog.LogHandling
 
             // ---------------------------------
             // Pass log data to Processor
-            logger.Process(logDatas);
+            await logger.Process(logDatas);
         }
 
         /// <summary>

--- a/jsnlog/LogHandling/LoggerProcessor.cs
+++ b/jsnlog/LogHandling/LoggerProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using JSNLog.Infrastructure;
 using System.Net;
@@ -62,7 +62,7 @@ namespace JSNLog.LogHandling
         {
             JsnlogConfiguration jsnlogConfiguration = JavascriptLogging.GetJsnlogConfiguration();
 
-            ILoggingAdapter logger = JavascriptLogging.GetLogger();
+            ILoggingBatchAdapter logger = JavascriptLogging.GetLogger();
 
             if ((httpMethod != "POST") && (httpMethod != "OPTIONS"))
             {
@@ -102,12 +102,8 @@ namespace JSNLog.LogHandling
                 ProcessLogRequestExec(json, logRequestBase, serverSideTimeUtc, jsnlogConfiguration);
 
             // ---------------------------------
-            // Pass log data to Common Logging
-
-            foreach (FinalLogData logData in logDatas)
-            {
-                logger.Log(logData);
-            }
+            // Pass log data to Processor
+            logger.Process(logDatas);
         }
 
         /// <summary>

--- a/jsnlog/PublicFacing/AspNet4/LogRequestHandling/HttpHandler/LoggerHandler.cs
+++ b/jsnlog/PublicFacing/AspNet4/LogRequestHandling/HttpHandler/LoggerHandler.cs
@@ -1,4 +1,4 @@
-﻿#if NETFRAMEWORK
+#if NETFRAMEWORK
 
 using System;
 using System.Collections.Generic;
@@ -9,6 +9,7 @@ using System.Collections.Specialized;
 using System.Xml;
 using JSNLog.LogHandling;
 using System.IO;
+using System.Threading.Tasks;
 using JSNLog.Infrastructure;
 using System.Web.SessionState;
 
@@ -25,14 +26,14 @@ namespace JSNLog
     // http://stackoverflow.com/questions/7247409/regarding-the-usage-of-irequiressessionstate
     // http://stackoverflow.com/questions/8039014/irequiressessionstate-vs-ireadonlysessionstate
 
-    public class LoggerHandler : IHttpHandler, IReadOnlySessionState
+    public class LoggerHandler : HttpTaskAsyncHandler, IReadOnlySessionState
     {
         public bool IsReusable
         {
             get { return true; }
         }
 
-        public void ProcessRequest(HttpContext context)
+        public override async Task ProcessRequestAsync(HttpContext context)
         {
             var logRequestBase = new LogRequestBase(
                 userAgent: context.Request.UserAgent,
@@ -55,7 +56,7 @@ namespace JSNLog
 
             var logResponse = new LogResponse();
 
-            LoggerProcessor.ProcessLogRequest(json, logRequestBase,
+            await LoggerProcessor.ProcessLogRequest(json, logRequestBase,
                 serverSideTimeUtc,
                 httpMethod, origin, logResponse);
 

--- a/jsnlog/PublicFacing/AspNet4/LogRequestHandling/Owin/JsnlogMiddlewareComponent.cs
+++ b/jsnlog/PublicFacing/AspNet4/LogRequestHandling/Owin/JsnlogMiddlewareComponent.cs
@@ -1,4 +1,4 @@
-﻿#if NETFRAMEWORK
+#if NETFRAMEWORK
 
 using System;
 using System.Collections.Generic;
@@ -39,7 +39,7 @@ namespace JSNLog
             {
                 try
                 {
-                    ProcessRequest(context);
+                    await ProcessRequest(context);
                 }
                 catch
                 {
@@ -54,7 +54,7 @@ namespace JSNLog
             await _next.Invoke(environment);
         }
 
-        private void ProcessRequest(IOwinContext context)
+        private async Task ProcessRequest(IOwinContext context)
         {
             var headers = ToDictionary(context.Request.Headers);
             string urlReferrer = headers.SafeGet("Referer");
@@ -83,7 +83,7 @@ namespace JSNLog
 
             var response = new LogResponse();
 
-            LoggerProcessor.ProcessLogRequest(json, logRequestBase,
+            await LoggerProcessor.ProcessLogRequest(json, logRequestBase,
                 serverSideTimeUtc,
                 httpMethod, origin, response);
 

--- a/jsnlog/PublicFacing/AspNet5/Configuration/Middleware/ApplicationBuilderExtensions.cs
+++ b/jsnlog/PublicFacing/AspNet5/Configuration/Middleware/ApplicationBuilderExtensions.cs
@@ -19,6 +19,21 @@ namespace JSNLog
         public static void UseJSNLog(this IApplicationBuilder builder,
             ILoggingAdapter loggingAdapter, JsnlogConfiguration jsnlogConfiguration = null)
         {
+            JavascriptLogging.SetJsnlogConfiguration(jsnlogConfiguration, LoggerToBatchAdapter.ToBatch(loggingAdapter));
+            builder.UseMiddleware<JSNLogMiddleware>();
+        }
+
+        /// <summary>
+        /// Normally, an ASP.NET 5 app would simply call this to insert JSNLog middleware into the pipeline.
+        /// Note that the loggingAdapter is required, otherwise JSNLog can't hand off log messages.
+        /// It can live without a configuration though (it will use default settings).
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="loggingAdapter"></param>
+        /// <param name="jsnlogConfiguration"></param>
+        public static void UseJSNLog(this IApplicationBuilder builder,
+            ILoggingBatchAdapter loggingAdapter, JsnlogConfiguration jsnlogConfiguration = null)
+        {
             JavascriptLogging.SetJsnlogConfiguration(jsnlogConfiguration, loggingAdapter);
             builder.UseMiddleware<JSNLogMiddleware>();
         }

--- a/jsnlog/PublicFacing/AspNet5/LogRequestHandling/Middleware/JSNLogMiddleware.cs
+++ b/jsnlog/PublicFacing/AspNet5/LogRequestHandling/Middleware/JSNLogMiddleware.cs
@@ -41,7 +41,7 @@ namespace JSNLog
             {
                 try
                 {
-                    ProcessRequest(context);
+                    await ProcessRequest(context);
                 }
                 catch (Exception e)
                 {
@@ -61,7 +61,7 @@ namespace JSNLog
             await next(context);
         }
 
-        private void ProcessRequest(HttpContext context)
+        private async Task ProcessRequest(HttpContext context)
         {
             var headers = ToDictionary(context.Request.Headers);
             string urlReferrer = headers.SafeGet("Referer");
@@ -90,7 +90,7 @@ namespace JSNLog
 
             var response = new LogResponse();
 
-            LoggerProcessor.ProcessLogRequest(json, logRequestBase,
+            await LoggerProcessor.ProcessLogRequest(json, logRequestBase,
                 serverSideTimeUtc,
                 httpMethod, origin, response);
 

--- a/jsnlog/PublicFacing/Configuration/ILoggingAdapter.cs
+++ b/jsnlog/PublicFacing/Configuration/ILoggingAdapter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Linq;
 using System.Text;
 using JSNLog;

--- a/jsnlog/PublicFacing/Configuration/ILoggingBatchAdapter.cs
+++ b/jsnlog/PublicFacing/Configuration/ILoggingBatchAdapter.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace JSNLog
+{
+    public interface ILoggingBatchAdapter
+    {
+        void Process(IEnumerable<FinalLogData> finalLogData);
+    }
+}

--- a/jsnlog/PublicFacing/Configuration/ILoggingBatchAdapter.cs
+++ b/jsnlog/PublicFacing/Configuration/ILoggingBatchAdapter.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace JSNLog
 {
     public interface ILoggingBatchAdapter
     {
-        void Process(IEnumerable<FinalLogData> finalLogData);
+        Task Process(IEnumerable<FinalLogData> finalLogData);
     }
 }

--- a/jsnlog/PublicFacing/Configuration/JavascriptLogging.cs
+++ b/jsnlog/PublicFacing/Configuration/JavascriptLogging.cs
@@ -104,11 +104,10 @@ namespace JSNLog
         // If targeting Net Framework whilst running in a Core web site, this will at first be 
         // wrongly set to the CommonLogging adapter. But it then gets overwritten by 
         // SetJsnlogConfiguration when that method is called by UseJsnlog.
-        private static ILoggingAdapter _logger = new CommonLoggingAdapter();
+        private static ILoggingBatchAdapter _logger = LoggerToBatchAdapter.ToBatch(new CommonLoggingAdapter());
 #else
-        private static ILoggingAdapter _logger = null;
+        private static ILoggingBatchAdapter _logger = null;
 #endif
-
 
         internal static JsnlogConfiguration GetJsnlogConfigurationWithoutWebConfig()
         {
@@ -160,13 +159,13 @@ namespace JSNLog
 #endif
         }
 
-        internal static ILoggingAdapter GetLogger()
+        internal static ILoggingBatchAdapter GetLogger()
         {
             return _logger;
         }
 
         internal static void SetJsnlogConfigurationWithoutWebConfig(
-            JsnlogConfiguration jsnlogConfiguration, ILoggingAdapter loggingAdapter = null)
+            JsnlogConfiguration jsnlogConfiguration, ILoggingBatchAdapter loggingAdapter = null)
         {
             _jsnlogConfiguration = jsnlogConfiguration;
 
@@ -182,7 +181,7 @@ namespace JSNLog
         // All unit tests run under DOTNETCLI
 #if NETFRAMEWORK
         internal static void SetJsnlogConfiguration(
-            Func<XmlElement> lxe, JsnlogConfiguration jsnlogConfiguration, ILoggingAdapter logger = null)
+            Func<XmlElement> lxe, JsnlogConfiguration jsnlogConfiguration, ILoggingBatchAdapter logger = null)
         {
             // Always allow setting the config to null, because GetJsnlogConfiguration retrieves web.config when config is null.
             if (jsnlogConfiguration != null)
@@ -199,7 +198,7 @@ namespace JSNLog
 #endif
 
         public static void SetJsnlogConfiguration(
-            JsnlogConfiguration jsnlogConfiguration, ILoggingAdapter loggingAdapter = null)
+            JsnlogConfiguration jsnlogConfiguration, ILoggingBatchAdapter loggingAdapter)
         {
 #if NETFRAMEWORK
             // When using ASP Net CORE with a Net Framework target (such as net47), 
@@ -211,5 +210,10 @@ namespace JSNLog
         }
 
 #endregion
+
+        public static void SetJsnlogConfiguration(JsnlogConfiguration jsnlogConfiguration, ILoggingAdapter loggingAdapter = null)
+        {
+            SetJsnlogConfiguration(jsnlogConfiguration, LoggerToBatchAdapter.ToBatch(loggingAdapter));
+        }
     }
 }

--- a/jsnlog/PublicFacing/Configuration/LoggerToBatchAdapter.cs
+++ b/jsnlog/PublicFacing/Configuration/LoggerToBatchAdapter.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace JSNLog
+{
+    public class LoggerToBatchAdapter : ILoggingBatchAdapter
+    {
+        private readonly ILoggingAdapter _adapter;
+
+        private LoggerToBatchAdapter(ILoggingAdapter adapter)
+        {
+            _adapter = adapter;
+        }
+
+        public void Process(IEnumerable<FinalLogData> finalLogData)
+        {
+            foreach (var data in finalLogData)
+            {
+                _adapter.Log(data);
+            }
+        }
+
+        public static ILoggingBatchAdapter ToBatch(ILoggingAdapter logger)
+        {
+            return logger == null ? null : new LoggerToBatchAdapter(logger);
+        }
+    }
+}

--- a/jsnlog/PublicFacing/Configuration/LoggerToBatchAdapter.cs
+++ b/jsnlog/PublicFacing/Configuration/LoggerToBatchAdapter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace JSNLog
 {
@@ -11,12 +12,14 @@ namespace JSNLog
             _adapter = adapter;
         }
 
-        public void Process(IEnumerable<FinalLogData> finalLogData)
+        public Task Process(IEnumerable<FinalLogData> finalLogData)
         {
             foreach (var data in finalLogData)
             {
                 _adapter.Log(data);
             }
+
+            return Task.FromResult(1);
         }
 
         public static ILoggingBatchAdapter ToBatch(ILoggingAdapter logger)


### PR DESCRIPTION
I tried to add this without breaking changes.
Basically our use case is that we want to control the processing in the server side and want to be able to process the complete batch sent from the client in a single run.

There might be another PR (or an addition to this PR) in order to make this processing asynchronous.