### PR TITLE
Convert 'ASP.NET 5' (ASP.NET Core) middleware to use async request processing

### DIFF
--- a/jsnlog/PublicFacing/AspNet5/LogRequestHandling/Middleware/JSNLogMiddleware.cs
+++ b/jsnlog/PublicFacing/AspNet5/LogRequestHandling/Middleware/JSNLogMiddleware.cs
@@ -41,7 +41,7 @@ namespace JSNLog
             {
                 try
                 {
-                    ProcessRequest(context);
+                    await ProcessRequestAsync(context);
                 }
                 catch (Exception e)
                 {
@@ -61,7 +61,7 @@ namespace JSNLog
             await next(context);
         }
 
-        private void ProcessRequest(HttpContext context)
+        private async Task ProcessRequestAsync(HttpContext context)
         {
             var headers = ToDictionary(context.Request.Headers);
             string urlReferrer = headers.SafeGet("Referer");
@@ -85,7 +85,7 @@ namespace JSNLog
             string json;
             using (var reader = new StreamReader(context.Request.Body, encoding))
             {
-                json = reader.ReadToEnd();
+                json = await reader.ReadToEndAsync();
             }
 
             var response = new LogResponse();


### PR DESCRIPTION
Firstly, for general efficiency - but also out of necessity if you want to turn kestrel's new 'strictly no blocking I/O' mode (see https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserveroptions.allowsynchronousio?view=aspnetcore-2.2).

