### PR TITLE
Trace context

### DIFF
--- a/jsnlog/LogHandling/LogRequest.cs
+++ b/jsnlog/LogHandling/LogRequest.cs
@@ -11,9 +11,12 @@ namespace JSNLog
         public DateTime UtcDate { get; private set; }
         public string EntryId { get; private set; }
         public string JsonMessage { get; private set; }
+        
+        public LogTraceContext TraceContext { get; }
 
         public LogRequest(string message, string logger, string level,
-            DateTime utcDate, string entryId, string jsonMessage, LogRequestBase logRequestBase)
+            DateTime utcDate, string entryId, string jsonMessage, LogRequestBase logRequestBase,
+            LogTraceContext traceContext)
             : base(logRequestBase)
         {
             Message = message;
@@ -22,6 +25,7 @@ namespace JSNLog
             UtcDate = utcDate;
             EntryId = entryId;
             JsonMessage = jsonMessage;
+            TraceContext = traceContext;
         }
 
         public override string ToString()

--- a/jsnlog/LogHandling/LoggerProcessor.cs
+++ b/jsnlog/LogHandling/LoggerProcessor.cs
@@ -10,21 +10,34 @@ namespace JSNLog.LogHandling
     internal class LoggerProcessor
     {
         /// <summary>
-        /// The log data sent in a single log request from the client.
-        /// It is expected that this list has 2 items:
-        /// * the requestId (key: r)
-        /// * the array with log items (key: lg)
+        /// Individual log item
         /// </summary>
-        
         private class LogRequestSingleMsg
         {
             public string m {get;set;}
             public string n {get;set;}
+            public LogRequestSingleTraceContext c { get; set; }
             public string l {get;set;}
             public string t {get;set;}
             public string u { get; set; }
         }
 
+        /// <summary>
+        /// W3C Trace Context (distributed trace-id, span-id, and parent span-id)
+        /// </summary>
+        private class LogRequestSingleTraceContext
+        {
+            public string d {get;set;}
+            public string p {get;set;}
+            public string s {get;set;}
+        }
+
+        /// <summary>
+        /// The log data sent in a single log request from the client.
+        /// It is expected that this list has 2 items:
+        /// * the requestId (key: r)
+        /// * the array with log items (key: lg)
+        /// </summary>
         private class LogRequestData
         {
             public string r {get;set;}
@@ -198,6 +211,12 @@ namespace JSNLog.LogHandling
             {
             }
 
+            LogTraceContext logTraceContext = null;
+            if (logItem.c != null)
+            {
+                logTraceContext = new LogTraceContext(logItem.c.d, logItem.c.s, logItem.c.p);
+            }
+
             // ----------------
 
             string jsonmessage = "";
@@ -208,7 +227,7 @@ namespace JSNLog.LogHandling
 
             // ----------------
 
-            var logRequest = new LogRequest(message, logger, level, utcDate, entryId, jsonmessage, logRequestBase);
+            var logRequest = new LogRequest(message, logger, level, utcDate, entryId, jsonmessage, logRequestBase, logTraceContext);
             var loggingEventArgs = new LoggingEventArgs(logRequest) 
             {
                 Cancel = false,

--- a/jsnlog/PublicFacing/AspNet5/Configuration/LoggingAdapter.cs
+++ b/jsnlog/PublicFacing/AspNet5/Configuration/LoggingAdapter.cs
@@ -25,14 +25,42 @@ namespace JSNLog
 
             Object message = LogMessageHelpers.DeserializeIfPossible(finalLogData.FinalMessage);
 
-            switch (finalLogData.FinalLevel)
+            IDisposable scope = null;
+            try
             {
-                case Level.TRACE: logger.LogTrace("{logMessage}", message); break;
-                case Level.DEBUG: logger.LogDebug("{logMessage}", message); break;
-                case Level.INFO: logger.LogInformation("{logMessage}", message); break;
-                case Level.WARN: logger.LogWarning("{logMessage}", message); break;
-                case Level.ERROR: logger.LogError("{logMessage}", message); break;
-                case Level.FATAL: logger.LogCritical("{logMessage}", message); break;
+                if (finalLogData.LogRequest.TraceContext != null)
+                {
+                    scope = logger.BeginScope("Client TraceContext: TraceId={TraceId},SpanId={SpanId},ParentId={ParentId}",
+                        finalLogData.LogRequest.TraceContext.TraceId,
+                        finalLogData.LogRequest.TraceContext.SpanId,
+                        finalLogData.LogRequest.TraceContext.ParentId ?? "0000000000000000");
+                }
+
+                switch (finalLogData.FinalLevel)
+                {
+                    case Level.TRACE:
+                        logger.LogTrace("{logMessage}", message);
+                        break;
+                    case Level.DEBUG:
+                        logger.LogDebug("{logMessage}", message);
+                        break;
+                    case Level.INFO:
+                        logger.LogInformation("{logMessage}", message);
+                        break;
+                    case Level.WARN:
+                        logger.LogWarning("{logMessage}", message);
+                        break;
+                    case Level.ERROR:
+                        logger.LogError("{logMessage}", message);
+                        break;
+                    case Level.FATAL:
+                        logger.LogCritical("{logMessage}", message);
+                        break;
+                }
+            }
+            finally
+            {
+                scope?.Dispose();
             }
         }
     }

--- a/jsnlog/PublicFacing/Configuration/ILogRequest.cs
+++ b/jsnlog/PublicFacing/Configuration/ILogRequest.cs
@@ -16,6 +16,8 @@ namespace JSNLog
         string RequestId { get; }
         string Url { get; }
 
+        LogTraceContext TraceContext { get; }
+        
         Dictionary<string, string> QueryParameters { get; }
         Dictionary<string, string> Cookies { get; }
         Dictionary<string, string> Headers { get; }

--- a/jsnlog/PublicFacing/Configuration/LogTraceContext.cs
+++ b/jsnlog/PublicFacing/Configuration/LogTraceContext.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics;
+
+namespace JSNLog
+{
+    public class LogTraceContext
+    {
+        public LogTraceContext(string traceId, string spanId, string parentId)
+        {
+            TraceId = traceId;
+            SpanId = spanId;
+            ParentId = parentId;
+        }
+        
+        public string ParentId { get; }
+        public string SpanId {get;}
+        public string TraceId {get;}
+    }
+}


### PR DESCRIPTION
Adds W3C Trace Context information to logs, either directly (as additional parameter) or via injected provider, and send them up to the server endpoint. This is the server side of the change; there is also a corresponding change in the JS client side.

**Background**

There is now a W3C standard for correlating distributed tracing. The standard is supported by .NET Core, by simply setting the traceparent header in a web api call, the trace-id and local span-id to be used as a parent will be sent to the server.

These can then be seen in the server as TraceId, ParentId (the client's span), and a new SpanId property (for the server operation) set in the scope, and automatically logged by providers such as Seq.

This passing of the trace-id during API calls is not part of JSNLog, but just how the ID is passed between the client and server, so both can generate logs.

**This Change**

This change allows the client-side trace-id, for the current operation (e.g. button press), current span-id, and any parent span-id to be sent up with each client log message. It is sent on the log message (rather than header), as multiple messages might be batched. Also, we aren't doing an API transfer call to generate a new span ID (as using the header would do), but passing up the raw values from the client for the client side log.

These are the injected in the scope on the server for logging the message.

This means any log statements from the client that happen due to the button press can be correlated with any events on the server, as they all have the same trace-id for that event. (Also the parent-id of any server traces would match the span-id of any client traces).
