### PR TITLE
#203 Only include tag helpers for net standard

### DIFF
--- a/jsnlog/jsnlog.csproj
+++ b/jsnlog/jsnlog.csproj
@@ -33,21 +33,20 @@
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 		<DefineConstants>NETCORE3</DefineConstants>
 	</PropertyGroup>
-	
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.*" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.*" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="2.*" />
+
+    <ItemGroup Condition="('$(TargetFramework)' == 'netstandard2.0') or ('$(TargetFramework)' == 'netstandard2.1')">
+		<PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.*" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.1.*" />
     </ItemGroup>
 
-	<!--assumes net452 no longer used-->
 	<ItemGroup Condition="('$(TargetFramework)' != 'netstandard2.0') AND ('$(TargetFramework)' != 'netstandard2.1')">
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Memory" Version="4.*" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.*" />
+		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
 	</ItemGroup>
 
   <ItemGroup>
@@ -56,6 +55,6 @@
       <PackagePath>readme.txt</PackagePath>
     </Content>
 	  <None Include="NuGet\icon.png" Pack="true" PackagePath=""/>
-  </ItemGroup>  
+  </ItemGroup>
 </Project>
 


### PR DESCRIPTION
This pull request is focused on reducing the dependencies and ensuring packages with CVE's are not being introduced into client applications.

The ASPNET Core libraries have had their version range constrained to the 2.1.x release due to 2.2.x being deprecated.

Newtonsoft version has been tied to the highest version required by other dependencies.

System.Memory was removed as not in use.

Closes: #203